### PR TITLE
Add option to run directly using `npx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Edit a JS file on CodePen:
 $ codepen example.js
 ```
 
+## Otherwise Execute directly
+
+Using [npx](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) which is a package runner bundled in `npm` 
+
+```bash
+npx @yuanchuan/codepen-cli index.html
+```
+
 ## Options
 
 #### keep-inline


### PR DESCRIPTION
Avoiding install a global install that need advice in case you updated the pckage, using `npx` you run always the last version.